### PR TITLE
Handle L2 reorgs in shutter-node

### DIFF
--- a/shutter-node/database/database.go
+++ b/shutter-node/database/database.go
@@ -31,7 +31,11 @@ func (d *Database) Connect(path string) error {
 	if path == "" {
 		return errors.New("no db path provided")
 	}
-	// path += "?cache=shared&mode=rwc"
+
+	// Enable the WAL mode for reader concurrency
+	// See https://github.com/mattn/go-sqlite3?tab=readme-ov-file#connection-string
+	// for more info.
+	path += "?mode=rwc&_journal_mode=WAL"
 	db, err := gorm.Open(sqlite.Open(path), &gorm.Config{})
 	if err != nil {
 		return nil
@@ -41,17 +45,7 @@ func (d *Database) Connect(path string) error {
 	if err != nil {
 		return errors.Wrap(err, "get sql interface db")
 	}
-
-	// TODO: enable read/write concurrency
-	// PRAGMA journal_mode=WAL;
-
-	// TODO: tweak if necessary, or remove...
-	// TODO: we might have to enable concurrency:
-	// PRAGMA busy_timeout = milliseconds;
-	idb.SetConnMaxIdleTime(500)
-	idb.SetMaxOpenConns(20)
 	idb.SetMaxIdleConns(10)
-
 	return errors.Wrap(d.AutoMigrate(), "auto migrate database")
 }
 

--- a/shutter-node/database/models/state.go
+++ b/shutter-node/database/models/state.go
@@ -26,8 +26,10 @@ type State struct {
 
 	Active bool
 
-	ActiveUpdate   ActiveUpdate
-	ActiveUpdateID uint
+	// this is the unpaused/paused state update
+	// that was *inserted* at the state's Block.
+	ActiveUpdate   *ActiveUpdate
+	ActiveUpdateID *uint
 }
 
 func (k *State) ModelVersion() uint {

--- a/shutter-node/database/query/get.go
+++ b/shutter-node/database/query/get.go
@@ -16,14 +16,14 @@ func GetActiveState(db *gorm.DB, block uint) (*models.ActiveUpdate, error) {
 	return CheckGetUniqueObject(update, res)
 }
 
-func GetLatestBlock(db *gorm.DB) (uint, error) {
+func GetLatestBlock(db *gorm.DB) (*uint, error) {
 	state := new(models.State)
 	db = db.Order("block DESC").Limit(1).Take(state)
 	state, err := CheckGetUniqueObject(state, db)
-	if err != nil {
-		return 0, err
+	if err != nil || state == nil {
+		return nil, err
 	}
-	return state.Block, nil
+	return &state.Block, nil
 }
 
 // This returns the latest COMITTED state.

--- a/shutter-node/database/writer/active.go
+++ b/shutter-node/database/writer/active.go
@@ -23,13 +23,13 @@ func ShutterStateToActive(s *syncevent.ShutterState) (*models.ActiveUpdate, erro
 	}, nil
 }
 
-func (w *DBWriter) handleShutterState(epk *syncevent.ShutterState) error {
-	w.log.Info("called HandleShutterState in syncer")
+func (w *DBWriter) handleShutterActive(epk *syncevent.ShutterState) error {
 	active, err := ShutterStateToActive(epk)
 	if err != nil {
 		return errors.Wrap(err, "convert event")
 	}
-	w.log.Debug("SHDEBUG: got shutter-active", "active", active.Active, "block", active.Block)
+	w.log.Info("handle shutter paused/unpaused event",
+		"unpaused", active.Active, "block", active.Block)
 	return w.db.Transaction(func(tx *gorm.DB) error {
 		result := tx.Create(active)
 		if result.Error != nil {

--- a/shutter-node/database/writer/service.go
+++ b/shutter-node/database/writer/service.go
@@ -46,7 +46,7 @@ func (w *DBWriter) HandleEventSync(ev any) error {
 	case *syncevent.LatestBlock:
 		err = w.handleLatestBlock(evTyped)
 	case *syncevent.ShutterState:
-		err = w.handleShutterState(evTyped)
+		err = w.handleShutterActive(evTyped)
 	case *models.Epoch:
 		err = w.handleNewEpoch(evTyped)
 	default:

--- a/shutter-node/grpc/v1/client/encoding.go
+++ b/shutter-node/grpc/v1/client/encoding.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"github.com/ethereum-optimism/optimism/shutter-node/grpc/v1"
-	"github.com/pkg/errors"
 	"github.com/shutter-network/shutter/shlib/shcrypto"
 )
 
@@ -10,27 +8,4 @@ type DecryptionKeyResult struct {
 	Block     uint
 	Active    bool
 	SecretKey *shcrypto.EpochSecretKey
-
-	Error error
-}
-
-func ToResult(in *grpc.DecryptionKey, err error) DecryptionKeyResult {
-	k := &DecryptionKeyResult{Error: err}
-	if in == nil && err == nil {
-		// XXX: error message
-		k.Error = errors.New("no values returned")
-	}
-	if in == nil {
-		return *k
-	}
-	k.Block = uint(in.Block)
-	k.Active = in.Active
-
-	key := &shcrypto.EpochSecretKey{}
-	if err := key.Unmarshal(in.Key); err != nil {
-		k.Error = errors.Wrap(err, "marshal error")
-		return *k
-	}
-	k.SecretKey = key
-	return *k
 }

--- a/shutter-node/shutter_test/tester.go
+++ b/shutter-node/shutter_test/tester.go
@@ -35,15 +35,14 @@ func Setup(ctx context.Context, t *testing.T) *Tester {
 	t.Helper()
 	db := &database.Database{}
 
-	f, err := os.CreateTemp("", "test-shutter-node-db.")
+	path, err := os.MkdirTemp("", "test-shutter-node-db-*")
 	assert.NilError(t, err)
 	// close and remove the temporary file at the end of the program
 	t.Cleanup(func() {
-		f.Close()
-		os.Remove(f.Name())
+		os.RemoveAll(path)
 	})
 
-	err = db.Connect(f.Name())
+	err = db.Connect(path + "/db")
 	assert.NilError(t, err)
 
 	logger := log.New()


### PR DESCRIPTION
While L2 re-orgs are not desirable from the perspective of shutter key-reveals triggered by new unsafe heads, this can eventually happen due to reorgs in L1.
Independent of the considerations for re-using already revealed key-identity values, the shutter-node should be able to handle re-orgs without shutting down or corrupting existing state.

In this PR, the  shutter-node will recognise re-orgs as they arrive via the L2 sync client (`rolling-shutter/medley/chainsync/`) and delete all state from the db that was present in the abandoned chain-branch (`gte` insert block than the new branch-off point) and then apply the new events as usually as they arrive from the stream.

**Note: this does not consider what happens when the gRPC API has requests waiting during the reorg - this could bare some edge-cases that are not accounted for currently**