### PR TITLE
Don't delete epoch keys upon reorgs

### DIFF
--- a/shutter-node/database/writer/block.go
+++ b/shutter-node/database/writer/block.go
@@ -38,10 +38,13 @@ func (w *DBWriter) deleteAbove(db *gorm.DB, blockNum uint) error {
 	if res.Error != nil {
 		return res.Error
 	}
-	res = db.Unscoped().Delete(&models.Epoch{}, "insert_block > ?", blockNum)
-	if res.Error != nil {
-		return res.Error
-	}
+	// NOTE: We don't delete the epoch keys we previously received,
+	// since they keypers currently don't rebroadcast them upon a reorg,
+	// and there would be a race condition even if they would do so.
+	// FIXME: Handle the edgecase, where during reorg the keyperset
+	// for that eon-index changes and the old, now invalid key is still
+	// present in the database. The new key currently would not be inserted into the
+	// db because of the "on-conflict do nothing" policy.
 	return nil
 }
 


### PR DESCRIPTION
Keypers are currently not re-broadcasting decryption keys upon a reorg, and thus the l2 block production will not progress.
With this PR, the shutter-node keeps old decryption keys in its database and allows the op-node to use the cached keys to build on top of the re-orged part of the chain.


This behaviour will result in a deactivation of shutter by the op-node, when the keyper-set that produced the cached keys changes during a reorg. That's because the shutter-node currently does not overwrite existing keys when the identity value already exists for that keyperset (eon-index).