### PR TITLE
use env variable for p2p sequencer key upon deployment

### DIFF
--- a/bedrock-devnet/devnet/sepolia.py
+++ b/bedrock-devnet/devnet/sepolia.py
@@ -108,6 +108,7 @@ def init_config(paths, l1_rpc):
     }, capture_output=True).stdout.decode("utf-8").strip('\n')
 
     deploy_config['l1StartingBlockTag'] = latest_hash
+    deploy_config['p2pSequencerAddress'] = os.getenv("P2P_SEQUENCER_PUBLIC_KEY")
     write_json(paths.devnet_config_path, deploy_config)
 
 

--- a/ops-bedrock/overrides/sepolia/docker-compose.override.yml
+++ b/ops-bedrock/overrides/sepolia/docker-compose.override.yml
@@ -11,7 +11,7 @@ services:
       --sequencer.enabled
       --sequencer.l1-confs=0
       --verifier.l1-confs=0
-      --p2p.sequencer.key=8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba
+      --p2p.sequencer.key=${P2P_SEQUENCER_PRIVATE_KEY}
       --rollup.config=/rollup.json
       --rpc.addr=0.0.0.0
       --rpc.port=8545

--- a/packages/contracts-bedrock/deploy-config/dev-sepolia-template.json
+++ b/packages/contracts-bedrock/deploy-config/dev-sepolia-template.json
@@ -8,7 +8,7 @@
   "maxSequencerDrift": 600,
   "sequencerWindowSize": 3600,
   "channelTimeout": 300,
-  "p2pSequencerAddress": "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc",
+  "p2pSequencerAddress": "",
   "batchInboxAddress": "0xff00000000000000000000000000000042055420",
   "batchSenderAddress": "0x3e376DfdF5A9a0e0E927c13cb7cf84a51DDDAF89",
   "l2OutputOracleSubmissionInterval": 120,


### PR DESCRIPTION
let's you use a customized p2p key upon sepolia deployment 